### PR TITLE
Use axle_tolerance to calculate spacing between axle and hole

### DIFF
--- a/scad/kbricks_core.scad
+++ b/scad/kbricks_core.scad
@@ -1074,11 +1074,11 @@ module peg_female() {
     union() {
         for(i=[0,1])
         rotate([180*i,0,0]) {
-            cylinder(7.5,3.1,3.1);
+            cylinder(7.5, 3 + axle_tolerance, 3 + axle_tolerance);
             translate([0,0,4])
-            cylinder(0.5,3.1,4.1);
+            cylinder(0.5, 3 + axle_tolerance, 4 + axle_tolerance);
             translate([0,0,4.5])
-            cylinder(3,4.1,4.1);
+            cylinder(3, 4 + axle_tolerance, 4 + axle_tolerance);
         }
     }
 }


### PR DESCRIPTION
This was hard-coded before and can now be configured with the
axle_tolerance parameter.

Let me know if I got it right; I'm aware this would also bump the default tolerance from 0.1 to 0.2 for axle vs. hole, but it actually was way too tight on my Anet A8.