### PR TITLE
Make hand printable flat

### DIFF
--- a/scad/kbricks_core.scad
+++ b/scad/kbricks_core.scad
@@ -412,7 +412,7 @@ module figure_hand() {
     r2 = axle_diameter/2 + axle_tolerance/2;
     difference() {
         union() {
-            rotate([180, 0, 0])
+            rotate([180, 0, 90])
             peg_half();
             translate([0, 0, cube_size/4])
             rotate([90, 0, 0])


### PR DESCRIPTION
rotate the slot in the peg so it aligns with the slot in the hand.

This makes it possible the print the hand flat with support only touching the buildplate.
I print them like this for strength.

My pegs break easily when i print them upwards.